### PR TITLE
fix: remap legacy API hostname in production env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 VITE_MCP_TARGET=local
 VITE_MCP_LOCAL_BASE_URL=
-VITE_MCP_REMOTE_BASE_URL=https://api.siftstylus.xyz
+VITE_MCP_REMOTE_BASE_URL=https://sifter.azule.xyz
 VITE_SKILLS_API_BASE_URL=
 VITE_OPENROUTER_PROXY_URL=/openrouter/chat/completions
 VITE_PROXY_TARGET=http://localhost:8001

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY . .
 
 ARG VITE_MCP_TARGET=local
 ARG VITE_MCP_LOCAL_BASE_URL=
-ARG VITE_MCP_REMOTE_BASE_URL=https://api.siftstylus.xyz
+ARG VITE_MCP_REMOTE_BASE_URL=https://sifter.azule.xyz
 ARG VITE_SKILLS_API_BASE_URL=
 ARG VITE_OPENROUTER_PROXY_URL=/openrouter/chat/completions
 ARG VITE_LLM_MODEL=openai/gpt-4o-mini

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Recommended local defaults:
 ```env
 VITE_MCP_TARGET=local
 VITE_MCP_LOCAL_BASE_URL=
-VITE_MCP_REMOTE_BASE_URL=https://api.siftstylus.xyz
+VITE_MCP_REMOTE_BASE_URL=https://sifter.azule.xyz
 VITE_SKILLS_API_BASE_URL=
 VITE_OPENROUTER_PROXY_URL=/openrouter/chat/completions
 VITE_PROXY_TARGET=http://localhost:8001

--- a/compose.server.yml
+++ b/compose.server.yml
@@ -7,9 +7,9 @@ services:
       args:
         VITE_MCP_TARGET: ${VITE_MCP_TARGET:-remote}
         VITE_MCP_LOCAL_BASE_URL: ${VITE_MCP_LOCAL_BASE_URL:-}
-        VITE_MCP_REMOTE_BASE_URL: ${VITE_MCP_REMOTE_BASE_URL:-https://api.siftstylus.xyz}
-        VITE_SKILLS_API_BASE_URL: ${VITE_SKILLS_API_BASE_URL:-https://api.siftstylus.xyz}
-        VITE_OPENROUTER_PROXY_URL: ${VITE_OPENROUTER_PROXY_URL:-https://api.siftstylus.xyz/openrouter/chat/completions}
+        VITE_MCP_REMOTE_BASE_URL: ${VITE_MCP_REMOTE_BASE_URL:-https://sifter.azule.xyz}
+        VITE_SKILLS_API_BASE_URL: ${VITE_SKILLS_API_BASE_URL:-https://sifter.azule.xyz}
+        VITE_OPENROUTER_PROXY_URL: ${VITE_OPENROUTER_PROXY_URL:-https://sifter.azule.xyz/openrouter/chat/completions}
         VITE_LLM_MODEL: ${VITE_LLM_MODEL:-openai/gpt-4o-mini}
         VITE_LLM_FALLBACK_MODEL: ${VITE_LLM_FALLBACK_MODEL:-anthropic/claude-3.5-haiku}
         VITE_SKILLS_INSTALLER_PACKAGE: ${VITE_SKILLS_INSTALLER_PACKAGE:-sift-stylus}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       args:
         VITE_MCP_TARGET: ${VITE_MCP_TARGET:-local}
         VITE_MCP_LOCAL_BASE_URL: ${VITE_MCP_LOCAL_BASE_URL:-}
-        VITE_MCP_REMOTE_BASE_URL: ${VITE_MCP_REMOTE_BASE_URL:-https://api.siftstylus.xyz}
+        VITE_MCP_REMOTE_BASE_URL: ${VITE_MCP_REMOTE_BASE_URL:-https://sifter.azule.xyz}
         VITE_SKILLS_API_BASE_URL: ${VITE_SKILLS_API_BASE_URL:-}
         VITE_OPENROUTER_PROXY_URL: ${VITE_OPENROUTER_PROXY_URL:-/openrouter/chat/completions}
         VITE_LLM_MODEL: ${VITE_LLM_MODEL:-openai/gpt-4o-mini}

--- a/src/config/env.js
+++ b/src/config/env.js
@@ -1,7 +1,7 @@
 const DEFAULTS = Object.freeze({
   mcpTarget: 'local',
   mcpLocalBaseUrl: '',
-  mcpRemoteBaseUrl: 'https://api.siftstylus.xyz',
+  mcpRemoteBaseUrl: 'https://sifter.azule.xyz',
   skillsApiBaseUrl: '',
   openRouterProxyUrl: '/openrouter/chat/completions',
   model: 'google/gemini-2.0-flash-exp',
@@ -11,13 +11,18 @@ const DEFAULTS = Object.freeze({
 });
 
 const normalizeMcpTarget = (value) => (String(value || '').trim().toLowerCase() === 'remote' ? 'remote' : 'local');
+const remapLegacyApiHost = (value) =>
+  String(value || '')
+    .trim()
+    .replace(/^https?:\/\/api\.siftstylus\.xyz(?=\/|$)/i, 'https://sifter.azule.xyz');
 
 const mcpTarget = normalizeMcpTarget(import.meta.env.VITE_MCP_TARGET || DEFAULTS.mcpTarget);
-const mcpLocalBaseUrl = import.meta.env.VITE_MCP_LOCAL_BASE_URL ?? DEFAULTS.mcpLocalBaseUrl;
-const mcpRemoteBaseUrl = import.meta.env.VITE_MCP_REMOTE_BASE_URL ?? DEFAULTS.mcpRemoteBaseUrl;
+const mcpLocalBaseUrl = remapLegacyApiHost(import.meta.env.VITE_MCP_LOCAL_BASE_URL ?? DEFAULTS.mcpLocalBaseUrl);
+const mcpRemoteBaseUrl = remapLegacyApiHost(import.meta.env.VITE_MCP_REMOTE_BASE_URL ?? DEFAULTS.mcpRemoteBaseUrl);
+const explicitSkillsApiBaseUrl = remapLegacyApiHost(import.meta.env.VITE_SKILLS_API_BASE_URL || '');
 
 const resolvedSkillsApiBaseUrl =
-  import.meta.env.VITE_SKILLS_API_BASE_URL ||
+  explicitSkillsApiBaseUrl ||
   (mcpTarget === 'remote' ? mcpRemoteBaseUrl : mcpLocalBaseUrl) ||
   DEFAULTS.skillsApiBaseUrl;
 
@@ -26,7 +31,7 @@ export const appEnv = Object.freeze({
   mcpLocalBaseUrl,
   mcpRemoteBaseUrl,
   skillsApiBaseUrl: resolvedSkillsApiBaseUrl,
-  openRouterProxyUrl: import.meta.env.VITE_OPENROUTER_PROXY_URL || DEFAULTS.openRouterProxyUrl,
+  openRouterProxyUrl: remapLegacyApiHost(import.meta.env.VITE_OPENROUTER_PROXY_URL || DEFAULTS.openRouterProxyUrl),
   model: import.meta.env.VITE_LLM_MODEL || DEFAULTS.model,
   fallbackModel: import.meta.env.VITE_LLM_FALLBACK_MODEL || DEFAULTS.fallbackModel,
   skillsInstallerPackage:


### PR DESCRIPTION
## Summary
- remap legacy `api.siftstylus.xyz` URLs to `https://sifter.azule.xyz` in frontend env resolution
- update frontend default env/build compose values to use `https://sifter.azule.xyz`
- keep compatibility with old secrets by remapping at runtime

## Validation
- npm run build
