### PR TITLE
fix: restore frontend production routing

### DIFF
--- a/compose.server.yml
+++ b/compose.server.yml
@@ -19,7 +19,7 @@ services:
     labels:
       - traefik.enable=true
       - traefik.docker.network=web-ag-ui_default
-      - traefik.http.routers.stylus-frontend.rule=Host(`siftstylus.xyz`) || Host(`www.siftstylus.xyz`)
+      - traefik.http.routers.stylus-frontend.rule=Host(`siftstylus.xyz`) || Host(`www.siftstylus.xyz`) || Host(`sifter.azule.xyz`) || Host(`stylus.azule.xyz`)
       - traefik.http.routers.stylus-frontend.entrypoints=websecure
       - traefik.http.routers.stylus-frontend.tls=true
       - traefik.http.routers.stylus-frontend.tls.certresolver=public

--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -26,6 +26,24 @@ server {
     proxy_pass $backend_upstream;
   }
 
+  location /admin {
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_pass $backend_upstream;
+  }
+
+  location = /feedback {
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_pass $backend_upstream/feedback;
+  }
+
   location = /openrouter/chat/completions {
     proxy_http_version 1.1;
     proxy_set_header Host $host;


### PR DESCRIPTION
## Summary
- route the frontend container for both the existing `siftstylus.xyz` hosts and the active azule hostnames
- proxy `/admin` and `/feedback` through the frontend nginx container alongside the existing backend paths
- document the outage diagnosis in issue `#7`

## Validation
- `npm run lint`
- `npm run build`

Closes #7
