### PR TITLE
fix: remove backend host from frontend router

### DIFF
--- a/compose.server.yml
+++ b/compose.server.yml
@@ -19,7 +19,7 @@ services:
     labels:
       - traefik.enable=true
       - traefik.docker.network=web-ag-ui_default
-      - traefik.http.routers.stylus-frontend.rule=Host(`siftstylus.xyz`) || Host(`www.siftstylus.xyz`) || Host(`sifter.azule.xyz`) || Host(`stylus.azule.xyz`)
+      - traefik.http.routers.stylus-frontend.rule=Host(`siftstylus.xyz`) || Host(`www.siftstylus.xyz`) || Host(`stylus.azule.xyz`)
       - traefik.http.routers.stylus-frontend.entrypoints=websecure
       - traefik.http.routers.stylus-frontend.tls=true
       - traefik.http.routers.stylus-frontend.tls.certresolver=public


### PR DESCRIPTION
## Summary
- remove `sifter.azule.xyz` from the frontend Traefik host rule
- keep frontend routing limited to `siftstylus.xyz`, `www.siftstylus.xyz`, and optional `stylus.azule.xyz`

## Validation
- `npm run lint`
- `npm run build`

Related to #7
