### PR TITLE
fix(chat): remap unavailable primary model

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,7 @@ VITE_PROXY_TARGET=http://localhost:8001
 VITE_SKILLS_INSTALLER_PACKAGE=sift-stylus-skills-installer
 VITE_SKILLS_INSTALL_REPO=getFairAI/angel-stylus-coding-assistant
 
-VITE_LLM_MODEL=google/gemini-2.0-flash-exp
+VITE_LLM_MODEL=openai/gpt-4o-mini
 VITE_LLM_FALLBACK_MODEL=openai/gpt-4o-mini
 
 VITE_PROJECT_GITHUB_URL=

--- a/README.md
+++ b/README.md
@@ -109,8 +109,8 @@ Required GitHub repository secrets:
 - `VITE_MCP_REMOTE_BASE_URL`
 - `VITE_SKILLS_API_BASE_URL`
 - `VITE_OPENROUTER_PROXY_URL`
-- `VITE_LLM_MODEL` (optional)
-- `VITE_LLM_FALLBACK_MODEL` (optional)
+- `VITE_LLM_MODEL` (optional, defaults to `openai/gpt-4o-mini`; unavailable models are remapped to a supported default at runtime)
+- `VITE_LLM_FALLBACK_MODEL` (optional, defaults to `openai/gpt-4o-mini`)
 - `VITE_SKILLS_INSTALLER_PACKAGE` (optional)
 - `VITE_SKILLS_INSTALL_REPO` (optional)
 - `VITE_PROJECT_GITHUB_URL` (optional)

--- a/src/config/env.js
+++ b/src/config/env.js
@@ -4,12 +4,16 @@ const DEFAULTS = Object.freeze({
   mcpRemoteBaseUrl: 'https://sifter.azule.xyz',
   skillsApiBaseUrl: '',
   openRouterProxyUrl: '/openrouter/chat/completions',
-  model: 'google/gemini-2.0-flash-exp',
+  model: 'openai/gpt-4o-mini',
   fallbackModel: 'openai/gpt-4o-mini',
   skillsInstallerPackage: 'sift-stylus',
   skillsInstallRepo: 'getFairAI/angel-stylus-coding-assistant',
   projectGithubUrl: 'https://github.com/placeholder',
   projectXUrl: 'https://x.com/getFairAI',
+});
+
+const UNAVAILABLE_MODEL_REMAP = Object.freeze({
+  'google/gemini-2.0-flash-exp': DEFAULTS.model,
 });
 
 const normalizeMcpTarget = (value) => (String(value || '').trim().toLowerCase() === 'remote' ? 'remote' : 'local');
@@ -28,14 +32,27 @@ const resolvedSkillsApiBaseUrl =
   (mcpTarget === 'remote' ? mcpRemoteBaseUrl : mcpLocalBaseUrl) ||
   DEFAULTS.skillsApiBaseUrl;
 
+const normalizeModel = (value, fallback) => {
+  const normalized = String(value || '').trim();
+
+  if (!normalized) {
+    return fallback;
+  }
+
+  return UNAVAILABLE_MODEL_REMAP[normalized] || normalized;
+};
+
+const model = normalizeModel(import.meta.env.VITE_LLM_MODEL, DEFAULTS.model);
+const fallbackModel = normalizeModel(import.meta.env.VITE_LLM_FALLBACK_MODEL, DEFAULTS.fallbackModel);
+
 export const appEnv = Object.freeze({
   mcpTarget,
   mcpLocalBaseUrl,
   mcpRemoteBaseUrl,
   skillsApiBaseUrl: resolvedSkillsApiBaseUrl,
   openRouterProxyUrl: remapLegacyApiHost(import.meta.env.VITE_OPENROUTER_PROXY_URL || DEFAULTS.openRouterProxyUrl),
-  model: import.meta.env.VITE_LLM_MODEL || DEFAULTS.model,
-  fallbackModel: import.meta.env.VITE_LLM_FALLBACK_MODEL || DEFAULTS.fallbackModel,
+  model,
+  fallbackModel,
   skillsInstallerPackage:
     import.meta.env.VITE_SKILLS_INSTALLER_PACKAGE || DEFAULTS.skillsInstallerPackage,
   skillsInstallRepo: import.meta.env.VITE_SKILLS_INSTALL_REPO || DEFAULTS.skillsInstallRepo,


### PR DESCRIPTION
## Summary
- remap the known-dead Gemini primary model to `openai/gpt-4o-mini`
- default frontend model config to `openai/gpt-4o-mini`
- document the runtime remap so stale deploy secrets do not keep prod on a broken model

## Testing
- `pnpm lint`
- `pnpm build`

Closes #10
